### PR TITLE
fix: add time conversion for unix timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 *.test
 .idea
 vendor
-go.sum

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/osteele/tuesday v1.0.3 h1:SrCmo6sWwSgnvs1bivmXLvD7Ko9+aJvvkmDjB5G4FTU=
+github.com/osteele/tuesday v1.0.3/go.mod h1:pREKpE+L03UFuR+hiznj3q7j3qB1rUZ4XfKejwWFF2M=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test.liquid
+++ b/test.liquid
@@ -56,3 +56,15 @@
 {% endif %}
 
 {{ "March 14, 2016" | date: "%b %d, %y" }}
+
+{{ "now" | date: "%B %d %Y" }}
+
+{{ "now" | date: "%s" | plus: 432000 | date: "%B %d, %Y" }}
+
+{{ "now" | date: "%s" }}
+
+{{ "now" | date: "%s" | plus: 86400 }}
+
+{{ "now" | date: "%s" | plus: 86400 | date: "%Y-%m-%d" }}
+
+{{ "now" | date: "%s" | plus: 432000 | date: "%Y-%m-%d %H:%M:%S" }}

--- a/values/convert.go
+++ b/values/convert.go
@@ -2,7 +2,9 @@ package values
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 	"time"
@@ -74,6 +76,35 @@ func convertValueToFloat(value any, typ reflect.Type) (float64, error) {
 	return 0, conversionError("", value, typ)
 }
 
+// TODO: need to confirm if time conversion just needs to support unix time
+func convertToTime(value any) (time.Time, error) {
+	switch v := value.(type) {
+	case json.Number:
+		i, err := v.Int64()
+		if err != nil {
+			return time.Time{}, err
+		}
+		return time.Unix(i, 0), nil
+	case int64:
+		return time.Unix(v, 0), nil
+	case int:
+		return time.Unix(int64(v), 0), nil
+	case float64:
+		// float64 timestamp is only accepted when it represents an exact integer value.
+		// This prevents precision loss caused by IEEE-754 floating point representation.
+		if v < float64(math.MinInt64) || v > float64(math.MaxInt64) {
+			return time.Time{}, errors.New("value out of range for time conversion")
+		}
+		iv := int64(v)
+		if float64(iv) != v {
+			return time.Time{}, errors.New("float value is not an exact integer")
+		}
+		return time.Unix(iv, 0), nil
+	default:
+		return time.Time{}, errors.New("unsupported type for time conversion")
+	}
+}
+
 // Convert value to the type. This is a more aggressive conversion, that will
 // recursively create new map and slice values as necessary. It doesn't
 // handle circular references.
@@ -81,13 +112,20 @@ func convertValueToFloat(value any, typ reflect.Type) (float64, error) {
 func Convert(value any, typ reflect.Type) (any, error) { //nolint: gocyclo
 	value = ToLiquid(value)
 	rv := reflect.ValueOf(value)
+
 	// int.Convert(string) returns "\x01" not "1", so guard against that in the following test
 	if typ.Kind() != reflect.String && value != nil && rv.Type().ConvertibleTo(typ) {
 		return rv.Convert(typ).Interface(), nil
 	}
-	if typ == timeType && rv.Kind() == reflect.String {
-		return ParseDate(value.(string))
+
+	if typ == timeType {
+		if rv.Kind() == reflect.String {
+			return ParseDate(value.(string))
+		}
+
+		return convertToTime(value)
 	}
+
 	// currently unused:
 	// case reflect.PtrTo(r.Type()) == typ:
 	// 	return &value, nil


### PR DESCRIPTION
## Issue
Liquid date filter fails when using `"now" | date: "%s"` with plus because the result becomes a `float64 Unix timestamp` that cannot be converted back to time.Time.

## Changes
Added `Unix timestamp (float64, int64, int, json.Number)` → `time.Time` conversion support in `Convert()` using time.Unix().

## TODO
Currently supports only Unix timestamp conversion to address this specific issue. Additional time conversion cases may need to be considered if requirements expand.

## Ticket
https://app.notion.com/p/funnelishapp/liquid-time-conversion-float64-37cb581c0a64809396c9ef1b07c51c13

## Slack Link
https://funnelishteam.slack.com/archives/C077FRRDW8N/p1781107936354779
